### PR TITLE
[RSC-PATCH] Fix client manifest chunk scan when non-JS assets precede JS

### DIFF
--- a/fixtures/flight/__tests__/__e2e__/smoke.test.js
+++ b/fixtures/flight/__tests__/__e2e__/smoke.test.js
@@ -27,3 +27,60 @@ test('smoke test', async ({page}) => {
   await expect(consoleErrors).toEqual([]);
   await expect(pageErrors).toEqual([]);
 });
+
+test('records JS chunks for CSS-importing client component and loads it in both paths', async ({
+  page,
+  request,
+}) => {
+  const consoleErrors = [];
+  page.on('console', msg => {
+    const type = msg.type();
+    if (type === 'warn' || type === 'error') {
+      consoleErrors.push({type, text: msg.text()});
+    }
+  });
+
+  const pageErrors = [];
+  page.on('pageerror', error => {
+    pageErrors.push(error.stack || error.message);
+  });
+
+  await page.goto('/');
+
+  const manifestResponse = await request.get('/react-client-manifest.json');
+  expect(manifestResponse.ok()).toBe(true);
+  const manifest = await manifestResponse.json();
+
+  const moduleMetadata =
+    manifest.filePathToModuleMetadata ?? manifest;
+
+  const dynamicEntry = Object.entries(moduleMetadata).find(([key]) =>
+    key.includes('Dynamic.js')
+  );
+  expect(dynamicEntry).toBeTruthy();
+
+  const [, entry] = dynamicEntry;
+  expect(entry.chunks.length).toBeGreaterThan(0);
+
+  const filenames = entry.chunks.filter((_, index) => index % 2 === 1);
+  expect(
+    filenames.some(
+      name => typeof name === 'string' && name.endsWith('.js') && !name.endsWith('.hot-update.js')
+    )
+  ).toBe(true);
+  expect(
+    filenames.some(name => typeof name === 'string' && name.endsWith('.css'))
+  ).toBe(false);
+
+  await expect(page.getByTestId('dynamic-component')).toHaveCount(1);
+  await expect(pageErrors).toEqual([]);
+  await expect(consoleErrors).toEqual([]);
+
+  await page.getByRole('button', {name: 'Load dynamic import Component'}).click();
+
+  await expect(page.getByText('loaded dynamically:')).toBeVisible();
+  await expect(page.getByTestId('dynamic-component')).toHaveCount(2);
+
+  await expect(pageErrors).toEqual([]);
+  await expect(consoleErrors).toEqual([]);
+});

--- a/fixtures/flight/__tests__/__e2e__/smoke.test.js
+++ b/fixtures/flight/__tests__/__e2e__/smoke.test.js
@@ -55,13 +55,14 @@ test('records JS chunks for CSS-importing client component and loads it in both 
     manifest.filePathToModuleMetadata ?? manifest;
 
   const dynamicEntry = Object.entries(moduleMetadata).find(([key]) =>
-    key.includes('Dynamic.js')
+    /\/Dynamic\.js$/.test(key)
   );
   expect(dynamicEntry).toBeTruthy();
 
   const [, entry] = dynamicEntry;
   expect(entry.chunks.length).toBeGreaterThan(0);
 
+  // chunks array is [chunkId, filename, chunkId, filename, …] pairs
   const filenames = entry.chunks.filter((_, index) => index % 2 === 1);
   expect(
     filenames.some(

--- a/fixtures/flight/src/Dynamic.css
+++ b/fixtures/flight/src/Dynamic.css
@@ -1,0 +1,3 @@
+.dynamic-component {
+  color: blue;
+}

--- a/fixtures/flight/src/Dynamic.js
+++ b/fixtures/flight/src/Dynamic.js
@@ -1,10 +1,11 @@
 'use client';
 
 import * as React from 'react';
+import './Dynamic.css';
 
 export function Dynamic() {
   return (
-    <div>
+    <div data-testid="dynamic-component" className="dynamic-component">
       This client component should be loaded in a single chunk even when it is
       used as both a client reference and as a dynamic import.
     </div>

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -279,10 +279,10 @@ export default class ReactFlightWebpackPlugin {
             chunkGroup.chunks.forEach(function (c) {
               // eslint-disable-next-line no-for-of-loops/no-for-of-loops
               for (const file of c.files) {
-                if (!file.endsWith('.js')) return;
-                if (file.endsWith('.hot-update.js')) return;
-                chunks.push(c.id, file);
-                break;
+                if (file.endsWith('.js') && !file.endsWith('.hot-update.js')) {
+                  chunks.push(c.id, file);
+                  break;
+                }
               }
             });
 


### PR DESCRIPTION
## Summary

The chunk file scan in `ReactFlightWebpackPlugin` used early `return` inside a `forEach` callback, which aborted the entire chunk when a non-JS file (e.g. CSS from `MiniCssExtractPlugin`) appeared first in `c.files`.

This caused the JS chunk pair to be omitted from `react-client-manifest.json`, breaking Flight's runtime preload step — the client would try to execute the module before webpack had actually loaded its async chunk.

The fix collapses the two separate guards into a single `if` condition that only matches real JS files (`file.endsWith('.js') && !file.endsWith('.hot-update.js')`), letting non-JS files fall through to the next loop iteration naturally.

## How did you test this change?

1. Added a CSS import to the existing `'use client'` module `fixtures/flight/src/Dynamic.js` (via new `Dynamic.css`) to reproduce the bug — this causes `MiniCssExtractPlugin` to place a `.css` file before `.js` in `chunk.files`.

2. Built the fixture (`cd fixtures/flight && node scripts/build.js`).

3. Verified the manifest with `node scripts/verify-manifest.js`, which asserts:
   - `Dynamic.js` has a non-empty `chunks` array
   - The `chunks` array contains a real JS chunk filename
   - No CSS files leaked into the `chunks` array

**Before fix:**
```
FAIL: Dynamic.js has an empty chunks array.
Entry: { "id": 588, "chunks": [], "name": "*" }
```

**After fix:**
```
PASS: Dynamic.js manifest entry is correct.
  Key: file:///...fixtures/flight/src/Dynamic.js
  ID: 588
  Chunks: [898,"static/js/client4.abf8d3b9.chunk.js"]
  Name: *
```
