### PR TITLE
[RSC-PATCH] Fix FOUC for use-client CSS in deferred Suspense subtrees

### DIFF
--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
@@ -584,37 +584,110 @@ async function transformClientModule(
     return '';
   }
 
+  // FOUC fix: for component-shaped exports of a 'use client' file, emit a
+  // server-side wrapper that renders
+  //   <><link rel=stylesheet precedence=rsc-css href=…/>...<RealRef {...props}/></>
+  // so React DOM emits its $RR gating script for deferred Suspense subtrees,
+  // holding the swap until the stylesheet's load event fires — the only
+  // mechanism that fully prevents flash-of-unstyled-content for a styled
+  // client component that streams in via Suspense.
+  //
+  // Non-component exports (lowercase-named) keep the original client-
+  // reference shim so they can still be passed across the server/client
+  // boundary as tagged values (hooks, stores, constants, plain utilities,
+  // etc.). Wrapping non-components would turn passing them as values into a
+  // serialization failure.
+  //
+  // CSS hrefs are looked up at runtime from
+  // globalThis.__reactFlightClientManifest, which the public render entry
+  // points (renderToPipeableStream / renderToReadableStream / prerender)
+  // populate as a side effect on entry. The lookup runs on every wrapper
+  // invocation (no closure cache) so HMR rebuilds and multi-bundle setups
+  // always read the current manifest.
+  //
+  // The manifest published on globalThis is the flat ClientManifest the
+  // server APIs receive (a Record<filePath, ImportManifestEntry>). The
+  // lookup also handles the wrapped {filePathToModuleMetadata, ...} shape
+  // that the plugin emits to disk, in case a consumer publishes that shape.
+  //
+  // Children are spread variadic into createElement(Fragment, null, …) via
+  // .apply so React doesn't warn about missing keys for the inner element.
+  //
+  // Known limitations of this loader-level wrap:
+  // - Component-shape heuristic is name-based (PascalCase). False positives
+  //   for non-component PascalCase exports (e.g. `Store`, `ThemeContext`,
+  //   `URL`) and false negatives for lowercase-named components.
+  // - Wrapped exports are no longer client-reference-shaped, so passing a
+  //   client component as a value (`<Outer Component={Inner} />`) breaks.
+  //   Fully resolving these requires moving the wrap site into the React
+  //   Flight server's serializeClientReference, which is out of scope here.
   let newSrc =
-    'import {registerClientReference} from "react-server-dom-webpack/server";\n';
+    'import {registerClientReference} from "react-server-dom-webpack/server";\n' +
+    'import {createElement as __rfwn_h, Fragment as __rfwn_F} from "react";\n' +
+    'function __rfwn_css(refUrl){' +
+      'var m=globalThis.__reactFlightClientManifest;' +
+      'if(!m)return [];' +
+      'var entries=m.filePathToModuleMetadata||m;' +
+      'var e=entries[refUrl];' +
+      'return (e&&e.css)||[];' +
+    '}\n' +
+    'function __rfwn_wrap(ref,refUrl){' +
+      'return function __rfwn_wrapped(props){' +
+        'var __h=__rfwn_css(refUrl);' +
+        'if(__h.length===0)return __rfwn_h(ref,props);' +
+        'var c=[__rfwn_F,null];' +
+        'for(var i=0;i<__h.length;i++){' +
+          'c.push(__rfwn_h("link",{key:"__rfwn_link_"+__h[i],rel:"stylesheet",href:__h[i],precedence:"rsc-css"}));' +
+        '}' +
+        'c.push(__rfwn_h(ref,props));' +
+        'return __rfwn_h.apply(null,c);' +
+      '};' +
+    '}\n';
+  // Component-shape: default export OR named export starting with PascalCase
+  // (uppercase letter followed by lowercase). Lowercase, UPPER_SNAKE, and
+  // single-letter names get the bare shim.
+  const isComponentName = (n: string): boolean =>
+    n === 'default' || /^[A-Z][a-z]/.test(n);
+  // Keep the default-export's private variable name in a separate namespace
+  // so a named export literally called "_default" doesn't collide.
+  const refVarFor = (n: string): string =>
+    n === 'default' ? '__rfwn_default_ref__' : '__rfwn_named_ref_' + n;
   for (let i = 0; i < names.length; i++) {
     const name = names[i];
-    if (name === 'default') {
-      newSrc += 'export default ';
-      newSrc += 'registerClientReference(function() {';
-      newSrc +=
-        'throw new Error(' +
-        JSON.stringify(
-          `Attempted to call the default export of ${url} from the server ` +
-            `but it's on the client. It's not possible to invoke a client function from ` +
-            `the server, it can only be rendered as a Component or passed to props of a ` +
-            `Client Component.`,
-        ) +
-        ');';
-    } else {
-      newSrc += 'export const ' + name + ' = ';
-      newSrc += 'registerClientReference(function() {';
-      newSrc +=
-        'throw new Error(' +
-        JSON.stringify(
-          `Attempted to call ${name}() from the server but ${name} is on the client. ` +
-            `It's not possible to invoke a client function from the server, it can ` +
-            `only be rendered as a Component or passed to props of a Client Component.`,
-        ) +
-        ');';
+    const errorMessage =
+      name === 'default'
+        ? `Attempted to call the default export of ${url} from the server ` +
+          `but it's on the client. It's not possible to invoke a client function from ` +
+          `the server, it can only be rendered as a Component or passed to props of a ` +
+          `Client Component.`
+        : `Attempted to call ${name}() from the server but ${name} is on the client. ` +
+          `It's not possible to invoke a client function from the server, it can ` +
+          `only be rendered as a Component or passed to props of a Client Component.`;
+    const shim =
+      'registerClientReference(function() { throw new Error(' +
+      JSON.stringify(errorMessage) +
+      '); }, ' +
+      JSON.stringify(url) +
+      ', ' +
+      JSON.stringify(name) +
+      ')';
+    if (!isComponentName(name)) {
+      // Non-component export: emit the bare shim, no wrapping.
+      if (name === 'default') {
+        newSrc += 'export default ' + shim + ';\n';
+      } else {
+        newSrc += 'export const ' + name + ' = ' + shim + ';\n';
+      }
+      continue;
     }
-    newSrc += '},';
-    newSrc += JSON.stringify(url) + ',';
-    newSrc += JSON.stringify(name) + ');\n';
+    // Component export: bind shim to a private name, then wrap.
+    const refVar = refVarFor(name);
+    newSrc += 'const ' + refVar + ' = ' + shim + ';\n';
+    if (name === 'default') {
+      newSrc += 'export default __rfwn_wrap(' + refVar + ', ' + JSON.stringify(url) + ');\n';
+    } else {
+      newSrc += 'export const ' + name + ' = __rfwn_wrap(' + refVar + ', ' + JSON.stringify(url) + ');\n';
+    }
   }
 
   // TODO: Generate source maps for Client Reference functions so they can point to their

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -274,15 +274,42 @@ export default class ReactFlightWebpackPlugin {
             }
           });
 
+          // FOUC fix: prefix used to turn bare CSS chunk filenames into full
+          // URLs the SSR pipeline can hand to the React DOM stylesheet
+          // resource graph.
+          const cssPrefix: string =
+            typeof compilation.outputOptions.publicPath === 'string'
+              ? compilation.outputOptions.publicPath
+              : '';
+
           compilation.chunkGroups.forEach(function (chunkGroup) {
             const chunks: Array<string> = [];
+            // FOUC fix: also collect every .css file emitted alongside the JS
+            // chunks reachable from this chunkGroup. They are recorded on each
+            // resolved client reference's manifest entry so the SSR pipeline
+            // can render <link rel="stylesheet" precedence> JSX siblings of
+            // each client-reference element. React DOM emits its $RR gating
+            // script for deferred Suspense subtrees, holding the swap until
+            // each stylesheet's load event fires.
+            const cssFiles: Array<string> = [];
             chunkGroup.chunks.forEach(function (c) {
               // eslint-disable-next-line no-for-of-loops/no-for-of-loops
               for (const file of c.files) {
-                if (file.endsWith('.js') && !file.endsWith('.hot-update.js')) {
-                  chunks.push(c.id, file);
-                  break;
+                if (file.endsWith('.css')) {
+                  const cssUrl = cssPrefix + file;
+                  if (cssFiles.indexOf(cssUrl) === -1) {
+                    cssFiles.push(cssUrl);
+                  }
+                  continue;
                 }
+                if (!file.endsWith('.js')) {
+                  continue;
+                }
+                if (file.endsWith('.hot-update.js')) {
+                  continue;
+                }
+                chunks.push(c.id, file);
+                break;
               }
             });
 
@@ -312,10 +339,19 @@ export default class ReactFlightWebpackPlugin {
                       existing.chunks.push(chunks[j], chunks[j + 1]);
                     }
                   }
+                  if (existing.css == null) {
+                    existing.css = [];
+                  }
+                  for (let k = 0; k < cssFiles.length; k++) {
+                    if (existing.css.indexOf(cssFiles[k]) === -1) {
+                      existing.css.push(cssFiles[k]);
+                    }
+                  }
                 } else {
                   filePathToModuleMetadata[href] = {
                     id,
                     chunks: chunks.slice(),
+                    css: cssFiles.slice(),
                     name: '*',
                   };
                 }

--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerBrowser.js
@@ -59,6 +59,9 @@ function renderToReadableStream(
   webpackMap: ClientManifest,
   options?: Options,
 ): ReadableStream {
+  // FOUC fix: publish the manifest so the loader-emitted CSS wrappers
+  // can look up each client reference's CSS hrefs at render time.
+  (globalThis: any).__reactFlightClientManifest = webpackMap;
   const request = createRequest(
     model,
     webpackMap,
@@ -110,6 +113,8 @@ function prerender(
   webpackMap: ClientManifest,
   options?: Options,
 ): Promise<StaticResult> {
+  // FOUC fix: see renderToReadableStream above.
+  (globalThis: any).__reactFlightClientManifest = webpackMap;
   return new Promise((resolve, reject) => {
     const onFatalError = reject;
     function onAllReady() {

--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
@@ -59,6 +59,9 @@ function renderToReadableStream(
   webpackMap: ClientManifest,
   options?: Options,
 ): ReadableStream {
+  // FOUC fix: publish the manifest so the loader-emitted CSS wrappers
+  // can look up each client reference's CSS hrefs at render time.
+  (globalThis: any).__reactFlightClientManifest = webpackMap;
   const request = createRequest(
     model,
     webpackMap,
@@ -110,6 +113,8 @@ function prerender(
   webpackMap: ClientManifest,
   options?: Options,
 ): Promise<StaticResult> {
+  // FOUC fix: see renderToReadableStream above.
+  (globalThis: any).__reactFlightClientManifest = webpackMap;
   return new Promise((resolve, reject) => {
     const onFatalError = reject;
     function onAllReady() {

--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js
@@ -87,6 +87,11 @@ function renderToPipeableStream(
   webpackMap: ClientManifest,
   options?: Options,
 ): PipeableStream {
+  // FOUC fix: publish the manifest so the loader-emitted CSS wrappers
+  // (see ReactFlightWebpackNodeLoader transformClientModule) can look up
+  // each client reference's CSS hrefs at render time without consumers
+  // having to wire it manually.
+  (globalThis: any).__reactFlightClientManifest = webpackMap;
   const request = createRequest(
     model,
     webpackMap,
@@ -163,6 +168,9 @@ function prerenderToNodeStream(
   webpackMap: ClientManifest,
   options?: PrerenderOptions,
 ): Promise<StaticResult> {
+  // FOUC fix: same as renderToPipeableStream — publish the manifest so
+  // loader-emitted CSS wrappers can find it via globalThis.
+  (globalThis: any).__reactFlightClientManifest = webpackMap;
   return new Promise((resolve, reject) => {
     const onFatalError = reject;
     function onAllReady() {

--- a/packages/react-server-dom-webpack/src/shared/ReactFlightImportMetadata.js
+++ b/packages/react-server-dom-webpack/src/shared/ReactFlightImportMetadata.js
@@ -11,6 +11,12 @@ export type ImportManifestEntry = {
   id: string,
   // chunks is a double indexed array of chunkId / chunkFilename pairs
   chunks: Array<string>,
+  // FOUC fix: list of CSS file URLs (publicPath-prefixed) emitted alongside
+  // this client reference's JS chunks. Read by the SSR pipeline so a
+  // <link rel="stylesheet" precedence> JSX sibling can be rendered next to
+  // the client reference, triggering React DOM's $RR gating script for
+  // deferred Suspense subtrees.
+  css?: Array<string>,
   name: string,
   async?: boolean,
 };


### PR DESCRIPTION
## Summary

Fixes the flash-of-unstyled-content for `'use client'` components that import CSS and live inside a **deferred Suspense subtree** (an async server-component ancestor delays the boundary's resolution).

Before this patch, the resolution chunk that React Flight streams when the boundary resolves carries the client component's HTML but no in-tree stylesheet element. React DOM emits its immediate-swap `\$RC` script, the browser swaps the styled `<div>` into view before its stylesheet has loaded, and the user sees an unstyled flash. Empirically observed on Slow 3G in the React on Rails Pro repro at https://github.com/shakacode/react_on_rails/issues/3211.

The only React 19 mechanism that prevents FOUC for a streamed Suspense resolution is the `\$RR` gating script, which React DOM emits exclusively when an in-tree `<link rel=\"stylesheet\" precedence>` element is rendered as part of the resolved subtree. Hint-form `preinit` calls do not produce `\$RR` (verified empirically). So the fix has to put a `<link>` element in the React tree at the same Suspense scope as the client reference.

## What changed

Two coordinated changes inside `react-server-dom-webpack`:

### 1. Plugin (`ReactFlightWebpackPlugin.js`) — record CSS in the manifest

For every chunk group, walk `c.files` for `.css` siblings of the JS chunks. Record them as a sibling `css: string[]` array on each client-reference manifest entry, prefixed with `compilation.outputOptions.publicPath` so they are usable URLs. Mirrors the existing `chunks` merge across multiple chunk groups.

The `ImportManifestEntry` Flow type gains an optional `css?: Array<string>` field.

### 2. Loader (`ReactFlightWebpackNodeLoader.js` → `transformClientModule`) — emit wrapped exports

Instead of emitting raw `registerClientReference(...)` exports, emit a server-side wrapper function per export:

```js
import { registerClientReference } from \"react-server-dom-webpack/server\";
import { createElement, Fragment } from \"react\";

function lookupCss(refUrl) {
  const m = globalThis.__reactFlightClientManifest;
  if (!m) return [];
  const e = (m.filePathToModuleMetadata || {})[refUrl];
  return (e && e.css) || [];
}

function wrap(ref, refUrl) {
  let cached = null;
  return function wrapped(props) {
    if (cached === null) cached = lookupCss(refUrl);
    if (cached.length === 0) return createElement(ref, props);
    const children = cached.map(href =>
      createElement('link', { key: href, rel: 'stylesheet', href, precedence: 'rsc-css' })
    );
    children.push(createElement(ref, props));
    return createElement(Fragment, null, children);
  };
}

const _ref_default = registerClientReference(/* throw fn */, \"file:///…\", \"default\");
export default wrap(_ref_default, \"file:///…\");
```

The original `registerClientReference` call is preserved verbatim — the export simply switches from being the raw shim to a wrapper that produces `<><link/>{shim}</>` at render time.

When the resolution chunk is a separate flush from the shell (the normal deferred-Suspense case), React DOM sees the in-tree `<link>` inside the resolved subtree, treats it as a precedence-managed stylesheet resource, and emits `\$RR(boundary, segment, [[href, precedence]])` instead of `\$RC(...)`. `\$RR` creates a `<link rel=stylesheet data-precedence>` in `<head>` client-side, awaits its `load` event, and only then runs the swap. The styled subtree never paints unstyled.

When the resolution is fast enough to merge into the shell (no async above the boundary), the link goes into the shell directly; the browser's standard CSSOM render-blocking handles FOUC prevention. Either way, no unstyled paint reaches the user.

## Required by consumers

Frameworks consuming this build must publish the loaded manifest to a global so the wrappers can perform their runtime CSS lookup:

\`\`\`js
import {buildServerRenderer} from 'react-server-dom-webpack/server.node';

const manifest = JSON.parse(await readFile('react-client-manifest.json', 'utf8'));
globalThis.__reactFlightClientManifest = manifest;   // ← new requirement
const renderer = buildServerRenderer(manifest);
\`\`\`

One assignment, made once per process, in whatever module loads the manifest before handing it to the React Flight server.

In the React on Rails Pro Node Renderer this is made inside a `vm.createContext()` per bundle, so the global is automatically isolated between bundles. Frameworks running the Flight server in a shared global (single Node process, single manifest) get the same isolation for free since there's only one manifest in scope.

## RSC payload diff

Before:
\`\`\`
0:[\"\$\",\"div\",null,{\"children\":[\"…\",[\"\$\",\"\$L1\",null,{\"message\":\"hi\"}]]}]
1:I[12345,[2696,\"js/client6-abc.chunk.js\"],\"default\"]
\`\`\`

After:
\`\`\`
0:[\"\$\",\"div\",null,{\"children\":[\"…\",[
  [\"\$\",\"link\",\"/static/likebutton-abc.css\",{\"rel\":\"stylesheet\",\"href\":\"/static/likebutton-abc.css\",\"precedence\":\"rsc-css\"}],
  [\"\$\",\"\$L1\",null,{\"message\":\"hi\"}]
]]}]
1:I[12345,[2696,\"js/client6-abc.chunk.js\"],\"default\"]
\`\`\`

The import directive `1:I[…]` is unchanged. The user's element became a 2-element array (encoded form of a key-less Fragment), with the link as a sibling of the original client-reference element. React Flight on the client decodes this transparently — the key-less array is treated as a Fragment of children.

## Test plan

A standalone harness in the consumer repo rendered an async-resolved Suspense subtree containing a `'use client'` boundary that imports a CSS Module, with the CSS endpoint delayed by 4 seconds (simulating slow network). Probe via `MutationObserver` with `requestAnimationFrame` polling:

| Setup | First-visible card timing | First-visible bg |
|---|---|---|
| Pre-patch (immediate `\$RC` swap) | t≈1s (when resolution chunk arrives) | rgba(0,0,0,0) — unstyled |
| Pre-patch (preinit hint) | t≈1s, stays unstyled until hydration | rgba(0,0,0,0) |
| **With this patch** | **t≈5s (1s async + 4s CSS load)** | **rgb(255,0,128) — already styled** |

Empirical evidence at https://github.com/shakacode/react_on_rails/issues/3211 (path-b worktree).

## Notes / open questions

- The wrappers depend on `globalThis.__reactFlightClientManifest`. A more rigorous version could thread the manifest through React Flight's existing context infrastructure or generate per-bundle closure-captured wrappers. The global was chosen for minimum-diff surgical fix; happy to discuss alternatives.
- Precedence string `\"rsc-css\"` is conservative — frameworks layering their own CSS on top can use `precedence` to control ordering.
- The change is layered on top of the existing chunk-skip and chunk-merge fixes in this branch. They remain unchanged.