### PR TITLE
[Flight] Filter runtime chunk from per-module client manifest chunks

### DIFF
--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -279,6 +279,12 @@ export default class ReactFlightWebpackPlugin {
               for (const file of c.files) {
                 if (!file.endsWith('.js')) return;
                 if (file.endsWith('.hot-update.js')) return;
+                // Skip the runtime chunk: it is always loaded by the host page
+                // alongside any initial entry, so re-emitting it during the
+                // Flight stream would re-execute the webpack runtime IIFE,
+                // create a second module cache, and break singletons that
+                // depend on a single runtime instance.
+                if (runtimeChunkFiles.has(file)) return;
                 chunks.push(c.id, file);
                 break;
               }


### PR DESCRIPTION
## Summary

`ReactFlightWebpackPlugin` already collects `runtimeChunkFiles` and the source comment promises it is used "to filter out chunks that Flight will never need to load." The filter was never applied. As a result, when `output.runtimeChunk: 'single'` is configured, the runtime chunk file appears in every client reference's `chunks` array in `react-client-manifest.json`. React Flight then emits a `<script>` tag for that runtime URL alongside the host page's own runtime tag.

Browsers do not deduplicate identical `<script async>` tags by URL, so the webpack runtime IIFE is evaluated twice: a new `__webpack_require__`, a new module cache, and new chunk closures. Any module relying on singleton semantics (global registries, version-checked SDKs, registered client references) is loaded twice with two distinct instances and breaks at runtime.

This PR adds the missing one-line filter so Flight's per-module `chunks` excludes runtime chunk files. The initial entrypoint already loads them on the host page; Flight never needs to re-emit them.

## Repro

Configure a webpack build with:

```js
optimization: { runtimeChunk: 'single', splitChunks: { chunks: 'all' } }
```

Render any page that

1. Loads an initial entrypoint via a `<script>` tag in `<head>` (e.g. shakapacker `javascript_pack_tag`, Next-style bootstrap, custom HTML template), and
2. Streams a server component tree containing a `'use client'` boundary.

Inspect the rendered HTML: the same `runtime-<hash>.js` URL appears twice — once in the head's preload group and once inline in the streamed body via Float. In production builds the second runtime evaluates and breaks any singleton imported through the client bundle.

After this patch the manifest entry's `chunks` no longer contains the runtime file, Float emits one `<script>` per non-runtime chunk, and the runtime IIFE runs exactly once.

## Test plan

- [ ] Add unit test for `ReactFlightWebpackPlugin` asserting that `runtimeChunkFiles` are excluded from each module's `chunks` in the emitted client manifest
- [ ] Verify existing `react-server-dom-webpack` tests still pass
- [ ] Manual repro on a webpack build with `runtimeChunk: 'single'`: confirm runtime URL appears only once in the streamed HTML and that singletons survive