### PR TITLE
[RSC-PATCH] Filter runtime chunk from per-module client manifest chunks

### DIFF
--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -308,6 +308,14 @@ export default class ReactFlightWebpackPlugin {
                 if (file.endsWith('.hot-update.js')) {
                   continue;
                 }
+                // Skip the runtime chunk: it is always loaded by the host page
+                // alongside any initial entry, so re-emitting it during the
+                // Flight stream would re-execute the webpack runtime IIFE,
+                // create a second module cache, and break singletons that
+                // depend on a single runtime instance.
+                if (runtimeChunkFiles.has(file)) {
+                  continue;
+                }
                 chunks.push(c.id, file);
                 break;
               }

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -308,12 +308,20 @@ export default class ReactFlightWebpackPlugin {
                 if (file.endsWith('.hot-update.js')) {
                   continue;
                 }
-                // Skip the runtime chunk: it is always loaded by the host page
-                // alongside any initial entry, so re-emitting it during the
-                // Flight stream would re-execute the webpack runtime IIFE,
-                // create a second module cache, and break singletons that
-                // depend on a single runtime instance.
-                if (runtimeChunkFiles.has(file)) {
+                // Skip the runtime chunk on the CLIENT manifest only: it is
+                // always loaded by the host page alongside any initial entry,
+                // so re-emitting it during the Flight stream would re-execute
+                // the webpack runtime IIFE, create a second module cache, and
+                // break singletons that depend on a single runtime instance.
+                //
+                // We must NOT apply this filter to the server manifest. Server
+                // bundles commonly use LimitChunkCountPlugin({maxChunks: 1}),
+                // which collapses every chunk into the entry — making that
+                // single output file the entrypoint's runtime chunk. Filtering
+                // it out leaves every client reference with chunks: [], so the
+                // RSC encoder cannot resolve any client module reference and
+                // the Flight stream stalls.
+                if (!_this.isServer && runtimeChunkFiles.has(file)) {
                   continue;
                 }
                 chunks.push(c.id, file);


### PR DESCRIPTION
## Summary

`ReactFlightWebpackPlugin` already collects `runtimeChunkFiles` and the source comment promises it is used "to filter out chunks that Flight will never need to load." The filter was never applied. As a result, when `output.runtimeChunk: 'single'` is configured, the runtime chunk file appears in every client reference's `chunks` array in `react-client-manifest.json`, and React Flight emits a `<script>` tag for that runtime URL alongside the host page's own runtime tag.

Browsers do not deduplicate identical `<script async>` tags by URL: the webpack runtime IIFE is evaluated twice. The second evaluation creates a new `__webpack_require__`, a new module cache, and new closures for each chunk's modules. Any module imported as a singleton (global registries, version-checked SDKs, registered client references) is loaded twice with two distinct instances and breaks at runtime.

This PR adds the filter the comment promised: when iterating a chunk group's files for the manifest, skip files that belong to the collected runtime chunk set. Initial entrypoints already load these on the host page; Flight should never request them.

## Repro

Configure a webpack build with:

```js
optimization: { runtimeChunk: 'single', splitChunks: { chunks: 'all' } }
```

Render any page that

1. Loads an initial entrypoint via a `<script>` tag in the document head (shakapacker `javascript_pack_tag`, custom HTML template, etc.), and
2. Streams a server component tree containing a `'use client'` boundary.

Inspect the rendered HTML: the same `runtime-<hash>.js` URL appears twice — once in the head's preload group and once inline in the streamed body via Float. In production builds the second runtime evaluates and breaks any singleton imported through the client bundle (for example `ReactOnRails was already initialized by another bundle or runtime instance`).

After this patch the manifest entry's `chunks` no longer contains the runtime file, Float emits one `<script>` per non-runtime chunk, and the runtime IIFE runs exactly once.

## Test plan

- [ ] Add unit test asserting that `runtimeChunkFiles` are excluded from each module's `chunks` in the emitted client manifest
- [ ] Verify existing `react-server-dom-webpack` tests still pass
- [ ] Manual repro on a webpack build with `runtimeChunk: 'single'`: confirm runtime URL appears only once in the streamed HTML and that singletons survive